### PR TITLE
fixed TypeError on pip installing requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,13 @@
 import os
 from setuptools import setup, find_packages
 from pip.req import parse_requirements
+from pip.req.download import PipSession
 
 # parse_requirements() returns generator of pip.req.InstallRequirement objects
 if os.path.exists("requirements.txt"):
-    install_reqs = parse_requirements("requirements.txt")
+    install_reqs = parse_requirements("requirements.txt", session=PipSession())
 else:
-    install_reqs = parse_requirements("Flask_Captcha.egg-info/requires.txt")
+    install_reqs = parse_requirements("Flask_Captcha.egg-info/requires.txt", session=PipSession())
 
 # reqs is a list of requirement
 # e.g. ['django==1.5.1', 'mezzanine==1.4.6']

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os
 from setuptools import setup, find_packages
 from pip.req import parse_requirements
-from pip.req.download import PipSession
+from pip.download import PipSession
 
 # parse_requirements() returns generator of pip.req.InstallRequirement objects
 if os.path.exists("requirements.txt"):


### PR DESCRIPTION
 pip 6.0+ needs keyword argument 'session' to parse_requirements()

before fix:
[https://travis-ci.org/rickmer/rephone/builds/113879002#L161](https://travis-ci.org/rickmer/rephone/builds/113879002#L161)

after fix:
[https://travis-ci.org/rickmer/rephone/builds/113902490](https://travis-ci.org/rickmer/rephone/builds/113902490)
